### PR TITLE
Optimize applyHeaders by removing the closure

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -95,22 +95,24 @@
     return null;
   }
 
+  function applyHeaders(headers, res) {
+    for (var i = 0, n = headers.length; i < n; i++) {
+      var header = headers[i];
+      if (header) {
+        if (Array.isArray(header)) {
+          applyHeaders(header, res);
+        } else if (header.key === 'Vary' && header.value) {
+          vary(res, header.value);
+        } else if (header.value) {
+          res.setHeader(header.key, header.value);
+        }
+      }
+    }
+  }
+
   function cors(options, req, res, next) {
     var headers = [],
-      method = req.method && req.method.toUpperCase && req.method.toUpperCase(),
-      applyHeaders = function (headers, res) {
-        headers.forEach(function (header) {
-          if (header) {
-            if (Array.isArray(header)) {
-              applyHeaders(header, res);
-            } else if (header.key === 'Vary' && header.value) {
-              vary(res, header.value);
-            } else if (header.value) {
-              res.setHeader(header.key, header.value);
-            }
-          }
-        });
-      };
+      method = req.method && req.method.toUpperCase && req.method.toUpperCase();
 
     if (method === 'OPTIONS') {
       // preflight
@@ -194,4 +196,3 @@
   module.exports = middlewareWrapper;
 
 }());
-


### PR DESCRIPTION
The PR improves the performance for the CORS middleware:

1. Remove Array.forEach() to avoid creation of closures
2. Refactor applyHeaders to a standalone function for better reuse