### PR TITLE
Fix "Vary: origin" header added for "*"

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -12,7 +12,7 @@
     };
 
   function configureOrigin(options, req) {
-    if (!options.origin) {
+    if (!options.origin || options.origin === '*') {
       return {
         key: 'Access-Control-Allow-Origin',
         value: '*'


### PR DESCRIPTION
The "Vary: origin" header should be added only for specific origins, but currently the code adds it also to the wildcard origin ("*"). This would happen even if you called cors() without options, because the default origin is set to "*".
The issue is with the first condition in the configureOrigin function. If origin is not falsy, vary will be added. To fix this I just expanded the condition to check if the origin is "*".