### PR TITLE
Allow CORS module to forward preflights request to the next() handler

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,6 +170,7 @@ app.listen(80, function(){
 * `exposedHeaders`: Configures the **Access-Control-Expose-Headers** CORS header. Expects a comma-delimited string (ex: 'Content-Range,X-Content-Range') or an array (ex: `['Content-Range', 'X-Content-Range]`). If not specified, no custom headers are exposed.
 * `credentials`: Configures the **Access-Control-Allow-Credentials** CORS header. Set to `true` to pass the header, otherwise it is omitted.
 * `maxAge`: Configures the **Access-Control-Allow-Max-Age** CORS header. Set to an integer to pass the header, otherwise it is omitted.
+* `preflightContinue`: Pass the CORS preflight response to the next handler.
 
 For details on the effect of each CORS header, [read this article on HTML5 Rocks](http://www.html5rocks.com/en/tutorials/cors/).
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -8,7 +8,8 @@
   var vary = require('vary'),
     defaults = {
       origin: '*',
-      methods: 'GET,HEAD,PUT,PATCH,POST,DELETE'
+      methods: 'GET,HEAD,PUT,PATCH,POST,DELETE',
+      preflightContinue: false
     };
 
   function configureOrigin(options, req) {
@@ -122,8 +123,13 @@
       headers.push(configureAllowedHeaders(options, req));
       headers.push(configureMaxAge(options, req));
       applyHeaders(headers, res);
-      res.statusCode = 204;
-      res.end();
+
+      if (options.preflightContinue ) {
+        next();
+      } else {
+        res.statusCode = 204;
+        res.end();
+      }
     } else {
       // actual response
       headers.push(configureOrigin(options, req));
@@ -144,6 +150,9 @@
     }
     if (o.methods === undefined) {
       o.methods = defaults.methods;
+    }
+    if (o.preflightContinue === undefined) {
+      o.preflightContinue = defaults.preflightContinue;
     }
 
     // if options are static (either via defaults or custom options passed in), wrap in a function

--- a/test/cors.js
+++ b/test/cors.js
@@ -76,6 +76,25 @@
       cors()(req, res, next);
     });
 
+    it('don\'t shortcircuits preflight requests with preflightContinue option', function (done) {
+      // arrange
+      var req, res, next;
+      req = fakeRequest();
+      req.method = 'OPTIONS';
+      res = fakeResponse();
+      res.end = function () {
+        // assert
+        done('should not be called');
+      };
+      next = function () {
+        // assert
+        done();
+      };
+
+      // act
+      cors({preflightContinue: true})(req, res, next);
+    });
+
     it('normalizes method names', function (done) {
       // arrange
       var req, res, next;


### PR DESCRIPTION
The Express framework already implement an OPTIONS method for each exposed API which allows to discover available methods for example.

The CORS module shortcircuits this OPTIONS implementation with an HTTP 204 response.

This PR adds a `preflightContinue` options to the CORS module which allows to forward OPTIONS requests to next handlers after having added the cors headers without changing anything to the current module's default behaviour.
