### PR TITLE
Add exposed headers to non-CORS OPTIONS request

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -122,6 +122,7 @@
       headers.push(configureMethods(options, req));
       headers.push(configureAllowedHeaders(options, req));
       headers.push(configureMaxAge(options, req));
+      headers.push(configureExposedHeaders(options, req));
       applyHeaders(headers, res);
 
       if (options.preflightContinue ) {


### PR DESCRIPTION
Currently it's not possible to do a OPTIONS (non-CORS) request (even with `preflightContinue` enabled from #40) to retrieve the "Allow" header of an express app.

This patch allows a config such as:

``` javascript
app.use(cors({
	"credentials": true,
	"origin": true,
	"methods": ["GET","HEAD","PUT","PATCH","POST","DELETE", "OPTIONS"],
	"exposedHeaders": ["Server", "Content-Type", "Allow", "X-Powered-By"]
}));
```

and a call with e.g. jQuery to do:

``` javascript
res.getResponseHeader('Allow')
```