### PR TITLE
Allow array/regexp in options.origin

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -13,16 +13,27 @@
     };
 
   function configureOrigin(options, req) {
+    var origin = req.headers.origin;
     if (!options.origin || options.origin === '*') {
       return {
         key: 'Access-Control-Allow-Origin',
         value: '*'
       };
+    } else if (Array.isArray(options.origin)) {
+      return {
+        key: 'Access-Control-Allow-Origin',
+        value: options.origin.indexOf(origin) !== -1 ? origin : false
+      };
+    } else if (options.origin instanceof RegExp) {
+      return {
+        key: 'Access-Control-Allow-Origin',
+        value: origin.match(options.origin) ? origin : false
+      };
     } else {
       return [
         {
           key: 'Access-Control-Allow-Origin',
-          value: options.origin === true ? req.headers.origin : options.origin
+          value: options.origin === true ? origin : false
         },
         {
           key: 'Vary',


### PR DESCRIPTION
This patch allows specifying an array of allowed origins or a regular expression for that matter in options.origin, eliminating the burden of having to define a function for such simple tasks. This is in answer to issue #42.