### PR TITLE
Allow regexp as options.origin

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -31,7 +31,7 @@
       if (options.origin instanceof RegExp) {
         return varyHeadersOn('Origin', {
             key: 'Access-Control-Allow-Origin',
-            value: origin.match(opts.origin) ? origin : false
+            value: opts.origin.test(origin) ? origin : false
         });
       } else {
         return varyHeadersOn('Origin', {

--- a/lib/index.js
+++ b/lib/index.js
@@ -12,23 +12,33 @@
       preflightContinue: false
     };
 
+  function varyHeadersOn(vary, headers) {
+      headers = Array.isArray(headers) ? headers.slice(0) : [headers];
+      vary = Array.isArray(vary) ? vary : [vary];
+      for (var i = 0; i < vary.length; ++i)
+          headers.push({ key: 'Vary', value: vary[i] });
+      return headers;
+  }
+
   function configureOrigin(options, req) {
+    var origin = req.headers.origin;
     if (!options.origin || options.origin === '*') {
       return {
         key: 'Access-Control-Allow-Origin',
         value: '*'
       };
     } else {
-      return [
-        {
-          key: 'Access-Control-Allow-Origin',
-          value: options.origin === true ? req.headers.origin : options.origin
-        },
-        {
-          key: 'Vary',
-          value: 'Origin'
-        }
-      ];
+      if (options.origin instanceof RegExp) {
+        return varyHeadersOn('Origin', {
+            key: 'Access-Control-Allow-Origin',
+            value: origin.match(opts.origin) ? origin : false
+        });
+      } else {
+        return varyHeadersOn('Origin', {
+            key: 'Access-Control-Allow-Origin',
+            value: options.origin === true ? origin : options.origin
+        });
+      }
     }
   }
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -31,7 +31,7 @@
       if (options.origin instanceof RegExp) {
         return varyHeadersOn('Origin', {
             key: 'Access-Control-Allow-Origin',
-            value: opts.origin.test(origin) ? origin : false
+            value: options.origin.test(origin) ? origin : false
         });
       } else {
         return varyHeadersOn('Origin', {

--- a/test/cors.js
+++ b/test/cors.js
@@ -76,7 +76,7 @@
       cors()(req, res, next);
     });
 
-    it('don\'t shortcircuits preflight requests with preflightContinue option', function (done) {
+    it('doesn\'t shortcircuit preflight requests with preflightContinue option', function (done) {
       // arrange
       var req, res, next;
       req = fakeRequest();
@@ -184,6 +184,17 @@
 
         // act
         cors(options)(req, res, next);
+      });
+
+      it('matches request origin against regexp', function(done) {
+        var req = fakeRequest();
+        var res = fakeResponse();
+        var options = { origin: /^(.+\.)?request.com$/ };
+        cors(options)(req, res, function(err) {
+          should.not.exist(err);
+          res.getHeader('Access-Control-Allow-Origin').should.equal(req.headers.origin);
+          return done();
+        });
       });
 
       it('origin of false disables cors', function (done) {


### PR DESCRIPTION
This patch allows specifying an array of allowed origins or a regular expression for that matter in options.origin, eliminating the burden of having to define a function for such simple tasks. This is in answer to issue #42. Now with all unit tests passed.