### PR TITLE
Allow array of conditions as options.origin

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -31,7 +31,7 @@
       if (options.origin instanceof RegExp) {
         return varyHeadersOn('Origin', {
             key: 'Access-Control-Allow-Origin',
-            value: origin.match(opts.origin) ? origin : false
+            value: opts.origin.test(origin) ? origin : false
         });
       } else {
         return varyHeadersOn('Origin', {

--- a/lib/index.js
+++ b/lib/index.js
@@ -13,32 +13,53 @@
     };
 
   function varyHeadersOn(vary, headers) {
-      headers = Array.isArray(headers) ? headers.slice(0) : [headers];
       vary = Array.isArray(vary) ? vary : [vary];
+      headers = Array.isArray(headers) ? headers.slice(0) : [headers];
       for (var i = 0; i < vary.length; ++i)
-          headers.push({ key: 'Vary', value: vary[i] });
+        headers.push({ key: 'Vary', value: vary[i] });
       return headers;
+  }
+  
+  function isString(what) {
+    return typeof what === 'string' || what instanceof String;
+  }
+  
+  function matchOrigin(origin, check) {
+    if (Array.isArray(check)) {
+      for (var i = 0; i < check.length; ++i) {
+        if (matchOrigin(origin, check[i]))
+          return true;
+      }
+      return false;
+    } else if (isString(check)) {
+      return origin === check;
+    } else if (check instanceof RegExp) {
+      return check.test(origin);
+    } else {
+      return !!check;
+    }
   }
 
   function configureOrigin(options, req) {
     var origin = req.headers.origin;
     if (!options.origin || options.origin === '*') {
+      // allow any origin
       return {
         key: 'Access-Control-Allow-Origin',
         value: '*'
       };
+    } else if (isString(options.origin)) {
+      // fixed origin
+      return varyHeadersOn('Origin', {
+        key: 'Access-Control-Allow-Origin',
+        value: options.origin
+      });
     } else {
-      if (options.origin instanceof RegExp) {
-        return varyHeadersOn('Origin', {
-            key: 'Access-Control-Allow-Origin',
-            value: options.origin.test(origin) ? origin : false
-        });
-      } else {
-        return varyHeadersOn('Origin', {
-            key: 'Access-Control-Allow-Origin',
-            value: options.origin === true ? origin : options.origin
-        });
-      }
+      // reflect origin
+      return varyHeadersOn('Origin', {
+        key: 'Access-Control-Allow-Origin',
+        value: matchOrigin(origin, options.origin) ? origin : false
+      });
     }
   }
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -12,23 +12,33 @@
       preflightContinue: false
     };
 
+  function varyHeadersOn(vary, headers) {
+      headers = Array.isArray(headers) ? headers.slice(0) : [headers];
+      vary = Array.isArray(vary) ? vary : [vary];
+      for (var i = 0; i < vary.length; ++i)
+          headers.push({ key: 'Vary', value: vary[i] });
+      return headers;
+  }
+
   function configureOrigin(options, req) {
+    var origin = req.headers.origin;
     if (!options.origin || options.origin === '*') {
       return {
         key: 'Access-Control-Allow-Origin',
         value: '*'
       };
     } else {
-      return [
-        {
-          key: 'Access-Control-Allow-Origin',
-          value: options.origin === true ? req.headers.origin : options.origin
-        },
-        {
-          key: 'Vary',
-          value: 'Origin'
-        }
-      ];
+      if (options.origin instanceof RegExp) {
+        return varyHeadersOn('Origin', {
+            key: 'Access-Control-Allow-Origin',
+            value: origin.match(opts.origin) ? origin : false
+        });
+      } else {
+        return varyHeadersOn('Origin', {
+            key: 'Access-Control-Allow-Origin',
+            value: options.origin === true ? origin : options.origin
+        });
+      }
     }
   }
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -13,11 +13,11 @@
     };
 
   function varyHeadersOn(vary, headers) {
-      vary = Array.isArray(vary) ? vary : [vary];
-      headers = Array.isArray(headers) ? headers.slice(0) : [headers];
-      for (var i = 0; i < vary.length; ++i)
-        headers.push({ key: 'Vary', value: vary[i] });
-      return headers;
+    vary = Array.isArray(vary) ? vary : [vary];
+    headers = Array.isArray(headers) ? headers.slice(0) : [headers];
+    for (var i = 0; i < vary.length; ++i)
+      headers.push({ key: 'Vary', value: vary[i] });
+    return headers;
   }
   
   function isString(what) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -31,7 +31,7 @@
       if (options.origin instanceof RegExp) {
         return varyHeadersOn('Origin', {
             key: 'Access-Control-Allow-Origin',
-            value: opts.origin.test(origin) ? origin : false
+            value: options.origin.test(origin) ? origin : false
         });
       } else {
         return varyHeadersOn('Origin', {

--- a/test/cors.js
+++ b/test/cors.js
@@ -76,7 +76,7 @@
       cors()(req, res, next);
     });
 
-    it('don\'t shortcircuits preflight requests with preflightContinue option', function (done) {
+    it('doesn\'t shortcircuit preflight requests with preflightContinue option', function (done) {
       // arrange
       var req, res, next;
       req = fakeRequest();
@@ -184,6 +184,17 @@
 
         // act
         cors(options)(req, res, next);
+      });
+
+      it('matches request origin against regexp', function(done) {
+        var req = fakeRequest();
+        var res = fakeResponse();
+        var options = { origin: /^(.+\.)?request.com$/ };
+        cors(options)(req, res, function(err) {
+          should.not.exist(err);
+          res.getHeader('Access-Control-Allow-Origin').should.equal(req.headers.origin);
+          return done();
+        });
       });
 
       it('origin of false disables cors', function (done) {

--- a/test/cors.js
+++ b/test/cors.js
@@ -193,6 +193,19 @@
         cors(options)(req, res, function(err) {
           should.not.exist(err);
           res.getHeader('Access-Control-Allow-Origin').should.equal(req.headers.origin);
+          res.getHeader('Vary').should.equal('Origin');
+          return done();
+        });
+      });
+      
+      it('matches request origin against array of origin checks', function(done) {
+        var req = fakeRequest();
+        var res = fakeResponse();
+        var options = { origin: [ /foo\.com$/, 'request.com' ] };
+        cors(options)(req, res, function(err) {
+          should.not.exist(err);
+          res.getHeader('Access-Control-Allow-Origin').should.equal(req.headers.origin);
+          res.getHeader('Vary').should.equal('Origin');
           return done();
         });
       });


### PR DESCRIPTION
This PR fully addresses #42. It allows options.origin to be an array of all types currently supported in options.origin (String and RegExp). Unit tests added.